### PR TITLE
Fix for concurrency between Add() and Set()

### DIFF
--- a/prometheus/counter.go
+++ b/prometheus/counter.go
@@ -50,6 +50,7 @@ func NewCounter(opts CounterOpts) Counter {
 		opts.ConstLabels,
 	)
 	result := &counter{value: value{desc: desc, valType: CounterValue, labelPairs: desc.constLabelPairs}}
+	result.value.Set(0)
 	result.init(result) // Init self-collection.
 	return result
 }
@@ -90,6 +91,7 @@ func NewCounterVec(opts CounterOpts, labelNames []string) *CounterVec {
 				valType:    CounterValue,
 				labelPairs: makeLabelPairs(desc, lvs),
 			}}
+			result.value.Set(0)
 			result.init(result) // Init self-collection.
 			return result
 		}),

--- a/prometheus/counter_test.go
+++ b/prometheus/counter_test.go
@@ -28,25 +28,25 @@ func TestCounterAdd(t *testing.T) {
 		ConstLabels: Labels{"a": "1", "b": "2"},
 	}).(*counter)
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 	counter.Add(42)
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(43), counter.valInt; expected != got {
+	if expected, got := int64(43), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 
 	counter.Add(24.42)
-	if expected, got := 24.42, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 24.42, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(43), counter.valInt; expected != got {
+	if expected, got := int64(43), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 
@@ -134,26 +134,26 @@ func TestCounterAddInf(t *testing.T) {
 	}).(*counter)
 
 	counter.Inc()
-	if expected, got := 0.0, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := 0.0, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
 
 	counter.Add(math.Inf(1))
-	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := math.Inf(1), math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(1), counter.valInt; expected != got {
+	if expected, got := int64(1), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
 	counter.Inc()
-	if expected, got := math.Inf(1), math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := math.Inf(1), math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("Expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(2), counter.valInt; expected != got {
+	if expected, got := int64(2), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("Expected %d, got %d.", expected, got)
 	}
 
@@ -174,10 +174,10 @@ func TestCounterAddLarge(t *testing.T) {
 	// large overflows the underlying type and should therefore be stored in valBits
 	large := float64(math.MaxInt64 + 1)
 	counter.Add(large)
-	if expected, got := large, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := large, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(0), counter.valInt; expected != got {
+	if expected, got := int64(0), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 
@@ -196,10 +196,10 @@ func TestCounterAddSmall(t *testing.T) {
 	}).(*counter)
 	small := 0.000000000001
 	counter.Add(small)
-	if expected, got := small, math.Float64frombits(counter.valBits); expected != got {
+	if expected, got := small, math.Float64frombits(counter.s.Load().(*valueStore).valBits); expected != got {
 		t.Errorf("valBits expected %f, got %f.", expected, got)
 	}
-	if expected, got := int64(0), counter.valInt; expected != got {
+	if expected, got := int64(0), counter.s.Load().(*valueStore).valInt; expected != got {
 		t.Errorf("valInts expected %d, got %d.", expected, got)
 	}
 

--- a/prometheus/gauge_test.go
+++ b/prometheus/gauge_test.go
@@ -83,7 +83,7 @@ func TestGaugeConcurrency(t *testing.T) {
 		}
 		start.Done()
 
-		if expected, got := <-result, math.Float64frombits(gge.(*value).valBits); math.Abs(expected-got) > 0.000001 {
+		if expected, got := <-result, math.Float64frombits(gge.(*value).s.Load().(*valueStore).valBits); math.Abs(expected-got) > 0.000001 {
 			t.Fatalf("expected approx. %f, got %f", expected, got)
 			return false
 		}
@@ -147,7 +147,7 @@ func TestGaugeVecConcurrency(t *testing.T) {
 		start.Done()
 
 		for i := range sStreams {
-			if expected, got := <-results[i], math.Float64frombits(gge.WithLabelValues(string('A'+i)).(*value).valBits); math.Abs(expected-got) > 0.000001 {
+			if expected, got := <-results[i], math.Float64frombits(gge.WithLabelValues(string('A'+i)).(*value).s.Load().(*valueStore).valBits); math.Abs(expected-got) > 0.000001 {
 				t.Fatalf("expected approx. %f, got %f", expected, got)
 				return false
 			}


### PR DESCRIPTION
This puts the actual number values of *value in another struct behind an
atomic.Value. This means that all Add/Inc/Dec calls will simply need to
deference one more pointer. For the Set() calls it will simply create a
*new* valueStore and swap the atomic.Value.